### PR TITLE
Patches for "Inline for errors" and Drupal core

### DIFF
--- a/drupal/file-repeated-error-message-on-ajax-upload/7.43-file-repeated-error-message-on-ajax-upload-1792032-15.patch
+++ b/drupal/file-repeated-error-message-on-ajax-upload/7.43-file-repeated-error-message-on-ajax-upload-1792032-15.patch
@@ -1,0 +1,14 @@
+diff --git a/modules/file/file.module b/modules/file/file.module
+index 3d351fa..77fca71 100644
+--- a/modules/file/file.module
++++ b/modules/file/file.module
+@@ -280,7 +280,8 @@ function file_ajax_upload() {
+     $form['#suffix'] .= '<span class="ajax-new-content"></span>';
+   }
+ 
+-  $output = theme('status_messages') . drupal_render($form);
++  $form['#prefix'] .= theme('status_messages');
++  $output = drupal_render($form);
+   $js = drupal_add_js();
+   $settings = call_user_func_array('array_merge_recursive', $js['settings']['data']);
+ 

--- a/drupal/file-repeated-error-message-on-ajax-upload/README.md
+++ b/drupal/file-repeated-error-message-on-ajax-upload/README.md
@@ -1,0 +1,5 @@
+# Patch summary
+
+Fix the problem when image is successfully uploaded but the error message from the previous upload is still present on the page.
+Symptoms: File validation error message not removed after subsequent upload of valid file
+See https://www.drupal.org/node/1792032 for details.

--- a/ife/custom-form-id-is-not-saved/README.md
+++ b/ife/custom-form-id-is-not-saved/README.md
@@ -1,0 +1,5 @@
+# Patch summary
+
+Fix the problem when custom form_id entered in IFE settings isn't saved.
+Symptoms: Custom form ID entered in admin interface of module isn't saved.
+See https://www.drupal.org/node/2713107 for details.

--- a/ife/custom-form-id-is-not-saved/custom-form-id-is-not-saved-2713107-6.patch
+++ b/ife/custom-form-id-is-not-saved/custom-form-id-is-not-saved-2713107-6.patch
@@ -1,0 +1,34 @@
+diff --git a/ife.settings.inc b/ife.settings.inc
+index cee3cbc..cbbac92 100644
+--- a/ife.settings.inc
++++ b/ife.settings.inc
+@@ -99,8 +99,13 @@ function ife_settings_form($form, $form_state) {
+     '#options' => ife_message_display_options(),
+     '#default_value' => IFE_MESSAGE_DEFAULT,
+   );
++  // Submit button.
++  $form['submit'] = array(
++  '#type' => 'submit',
++  '#value' => t('Save configuration'),
++  );
+ 
+-  return system_settings_form($form);
++  return $form;
+ }
+ 
+ /**
+@@ -138,7 +143,13 @@ function ife_settings_form_validate($form, &$form_state) {
+  */
+ function ife_settings_form_submit($form, &$form_state) {
+   $values = $form_state['values'];
+-  
++
++  // Set general options.
++  variable_set('ife_show_form_ids', $values['ife_show_form_ids']);
++  variable_set('ife_display', $values['ife_display']);
++  variable_set('ife_position_inline_message', $values['ife_position_inline_message']);
++  variable_set('ife_general_message', $values['ife_general_message']);
++
+   // Write form_ids to the database.
+   $form_ids = $values['form_ids'];
+   array_pop($form_ids);

--- a/ife/parents-missing/7.x-2.x-dev-parents-missing-2341875-3.patch
+++ b/ife/parents-missing/7.x-2.x-dev-parents-missing-2341875-3.patch
@@ -1,0 +1,76 @@
+diff --git a/ife.module b/ife.module
+index 7720962..374395b 100644
+--- a/ife.module
++++ b/ife.module
+@@ -235,38 +235,40 @@ function ife_element_errors_set(&$element, $display, $carry_down = FALSE) {
+     return;
+   }
+ 
+-  // Check for errors and settings.
+-  $errors = form_get_errors();
+-  $element_id = implode('][', $element['#parents']);
+-  if (!empty($errors[$element_id])) {
+-    $error_message = $errors[$element_id];
+-
+-    // Get error id.
+-    $error_id = array_search($error_message, $_SESSION['messages']['error']);
+-
+-    if ($error_id !== FALSE) {
+-      if (isset($display) && $display != IFE_MESSAGE_LEAVE) {
+-        unset($_SESSION['messages']['error'][$error_id]);
+-        $_SESSION['messages']['error'] = array_values($_SESSION['messages']['error']);
++  if (!empty($element['#parents'])) {
++    // Check for errors and settings.
++    $errors = form_get_errors();
++    $element_id = implode('][', $element['#parents']);
++    if (!empty($errors[$element_id])) {
++      $error_message = $errors[$element_id];
++
++      // Get error id.
++      $error_id = array_search($error_message, $_SESSION['messages']['error']);
++
++      if ($error_id !== FALSE) {
++        if (isset($display) && $display != IFE_MESSAGE_LEAVE) {
++          unset($_SESSION['messages']['error'][$error_id]);
++          $_SESSION['messages']['error'] = array_values($_SESSION['messages']['error']);
++        }
++
++        if (count($_SESSION['messages']['error']) <= 0) {
++          unset($_SESSION['messages']['error']);
++        }
++
++        // Add error message to the element.
++        $element['#ife_error'] = $error_message;
++
++        // Add the position for the inline error message.
++        $element['#ife_error_position'] = variable_get('ife_position_inline_message', IFE_POSITION_INLINE_MESSAGE_AFTER);
++
++        // Add in our theme wrapper on the fly.
++        if (!isset($element['#theme_wrappers']) || !in_array('ife_form_element', $element['#theme_wrappers'])) {
++          $element['#theme_wrappers'][] = 'ife_form_element';
++        }
++
++        // Found a matching error, no need to continue.
++        return;
+       }
+-
+-      if (count($_SESSION['messages']['error']) <= 0) {
+-        unset($_SESSION['messages']['error']);
+-      }
+-
+-      // Add error message to the element.
+-      $element['#ife_error'] = $error_message;
+-
+-      // Add the position for the inline error message.
+-      $element['#ife_error_position'] = variable_get('ife_position_inline_message', IFE_POSITION_INLINE_MESSAGE_AFTER);
+-
+-      // Add in our theme wrapper on the fly.
+-      if (!isset($element['#theme_wrappers']) || !in_array('ife_form_element', $element['#theme_wrappers'])) {
+-        $element['#theme_wrappers'][] = 'ife_form_element';
+-      }
+-
+-      // Found a matching error, no need to continue.
+-      return;
+     }
+   }
+ 

--- a/ife/parents-missing/README.md
+++ b/ife/parents-missing/README.md
@@ -1,0 +1,5 @@
+# Patch summary
+
+Fix notice after form submit.
+Symptoms: Undefined index error due to missing $element['#parents'].
+See https://www.drupal.org/node/1792032 for details.


### PR DESCRIPTION
IFE:
1. Undefined index error due to missing $element['#parents'].
2. Custom form ID entered in admin interface of module isn't saved.

Drupal core:
1. File validation error message not removed after subsequent upload of valid file
