### PR TITLE
Add patch for saveguard.

### DIFF
--- a/hide_submit/hide_submit-per_fromid-1313192-13/README.md
+++ b/hide_submit/hide_submit-per_fromid-1313192-13/README.md
@@ -1,0 +1,6 @@
+# Patch summary
+
+This patch provide functional for hide submit button only on specific form.
+Forms ids can be specified on settings page of module.
+
+See https://www.drupal.org/node/1313192 for details.

--- a/hide_submit/hide_submit-per_fromid-1313192-13/hide_submit-per_fromid-1313192-13.patch
+++ b/hide_submit/hide_submit-per_fromid-1313192-13/hide_submit-per_fromid-1313192-13.patch
@@ -1,0 +1,77 @@
+From 15ee91e2ae3dbd0b9d6c49a1f6bf796293a9d683 Mon Sep 17 00:00:00 2001
+From: Yousef Bajawi <jose@josebcdev.com>
+Date: Sun, 3 Apr 2016 06:10:43 -0400
+Subject: [PATCH] re-roll latest dev and check_plain
+
+---
+ hide_submit.admin.inc | 25 +++++++++++++++++++++++++
+ hide_submit.module    | 10 +++++++++-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/hide_submit.admin.inc b/hide_submit.admin.inc
+index b87dc42..16fff2f 100644
+--- a/hide_submit.admin.inc
++++ b/hide_submit.admin.inc
+@@ -73,6 +73,31 @@ function hide_submit_settings() {
+     '#description' => t('This text will be shown to the user instead of the submit buttons.'),
+   );
+ 
++  $form['fieldset_advanced'] = array(
++    '#type' => 'fieldset',
++    '#title' => t('Advanced'),
++    '#collapsible' => TRUE,
++    '#collapsed' => TRUE,
++  );
++
++  $form['fieldset_advanced']['hide_submit_form_exclusion_mode'] = array(
++    '#type' => 'radios',
++    '#title' => t('Exclusion mode'),
++    '#default_value' => variable_get('hide_submit_form_exclusion_mode', HIDE_SUBMIT_EXCLUDE_LISTED_FORMS),
++    '#options' => array(
++      HIDE_SUBMIT_EXCLUDE_LISTED_FORMS   => t('Exclude listed forms'),
++      HIDE_SUBMIT_EXCLUDE_UNLISTED_FORMS => t('Exclude unlisted forms'),
++    ),
++    '#description' => t("Choose exclusion mode for listed forms. <br /> NOTE: Forms that are not part of drupal Form-API will not be affected by this configuration"),
++  );
++
++  $form['fieldset_advanced']['hide_submit_form_exclusion'] = array(
++    '#type' => 'textarea',
++    '#title' => t('Form-id exclusion list'),
++    '#default_value' => check_plain(variable_get('hide_submit_form_exclusion', '')),
++    '#description' => t("Here you can make a list of forms (form-id) you wish not to hide submit buttons . <br />For example you can exclude the login block submit button from hiding by typing <em>user_login_block</em>"),
++  );
++
+   return system_settings_form($form);
+ }
+ 
+diff --git a/hide_submit.module b/hide_submit.module
+index 1cae901..b34bbd5 100644
+--- a/hide_submit.module
++++ b/hide_submit.module
+@@ -7,6 +7,8 @@
+  * effective against accidentally clicking of the button by users with
+  * Javascript enabled (which is a very high percent of users).
+  */
++define('HIDE_SUBMIT_EXCLUDE_LISTED_FORMS',   0);
++define('HIDE_SUBMIT_EXCLUDE_UNLISTED_FORMS', 1);
+ 
+ /**
+  * Adds the settings.
+@@ -72,7 +74,13 @@ function hide_submit_form_alter(&$form, &$form_state, $form_id) {
+   if (user_access('bypass hide submit')) {
+     return;
+   }
+-  if (hide_submit_add_settings()) {
++  $exclude_forms = explode("\r\n", variable_get('hide_submit_form_exclusion', ''));
++  $mode = variable_get('hide_submit_form_exclusion_mode', HIDE_SUBMIT_EXCLUDE_LISTED_FORMS);
++
++  $listed = ($mode == HIDE_SUBMIT_EXCLUDE_LISTED_FORMS && !in_array($form_id, $exclude_forms));
++  $unlisted = ($mode == HIDE_SUBMIT_EXCLUDE_UNLISTED_FORMS && in_array($form_id, $exclude_forms));
++
++  if(hide_submit_add_settings() && ($listed || $unlisted)) {
+     hide_submit_attach_js_css($form);
+     $form['#after_build'][] = 'hide_submit_after_build';
+   }
+-- 
+1.9.1
+

--- a/saveguard/saveguard-forms-opt-in-out-203244-10/README.md
+++ b/saveguard/saveguard-forms-opt-in-out-203244-10/README.md
@@ -1,0 +1,4 @@
+# Patch summary
+
+Extends Form Settings to 3 options (Ajax-based): All forms, Form IDs list, Except Form_IDs
+See: https://www.drupal.org/node/203244

--- a/saveguard/saveguard-forms-opt-in-out-203244-10/saveguard-forms-opt-in-out-203244-10.patch
+++ b/saveguard/saveguard-forms-opt-in-out-203244-10/saveguard-forms-opt-in-out-203244-10.patch
@@ -1,0 +1,125 @@
+diff --git a/saveguard.module b/saveguard.module
+index b17bbb3..b6b883d 100644
+--- a/saveguard.module
++++ b/saveguard.module
+@@ -26,18 +26,71 @@ function saveguard_menu() {
+ /**
+  * Define a settings form.
+  */
+-function saveguard_admin_settings() {
+-  $form = array();
++function saveguard_admin_settings($form, $form_state) {
+ 
+   $form['saveguard_message'] = array(
+     '#type' => 'textfield',
+     '#title' => t('Popup Message'),
+     '#default_value' => variable_get('saveguard_message', NULL),
+   );
+-
++  $saveguard_forms_all = variable_get('saveguard_forms_all', 0);
++  $form['saveguard_forms_all'] = array(
++    '#type' => 'radios',
++    '#title' => t('Where it should apply'),
++    '#description' => t('Specify on which forms you want to apply the <strong>SaveGuard</strong>.'),
++    '#options' => array(
++      0 => t('All forms'), 
++      1 => t("Specify <strong>form_id</strong>'s"),
++      2 => t("All forms except these <strong>form_id</strong>'s"),
++    ),
++    '#default_value' => $saveguard_forms_all,
++    '#ajax' => array(
++      'callback' => 'saveguard_forms_all_choice',
++      'wrapper' => 'forms-all-lists',
++      'method' => 'replace',
++      'effect' => 'fade',
++    ),
++  );
++  $saveguard_forms_value = variable_get('saveguard_forms', '');
++  $saveguard_except_forms_value = variable_get('saveguard_except_forms', '');
++  $form['saveguard_forms_container'] = array(
++    '#type' => 'container',
++    '#prefix' => '<div id="forms-all-lists">',
++    '#suffix' => '</div>',
++  );
++  $form['saveguard_forms_container']['saveguard_forms'] = array(
++    '#type' => 'hidden',
++    '#default_value' => $saveguard_forms_value,
++  );
++  $form['saveguard_forms_container']['saveguard_except_forms'] = array(
++    '#type' => 'hidden',
++    '#default_value' => $saveguard_except_forms_value,
++  );
++  if ((isset($form_state['values']['saveguard_forms_all']) && $form_state['values']['saveguard_forms_all'] == 1) || (!isset($form_state['values']['saveguard_forms_all']) && $saveguard_forms_all == 1)) {
++    $form['saveguard_forms_container']['saveguard_forms'] = array(
++      '#type' => 'textarea',
++      '#title' => t("List of form_id's"),
++      '#description' => t("Specify a list of all form_id's where you want SaveGuard to apply."),
++      '#default_value' => $saveguard_forms_value,
++    );
++  }
++  if ((isset($form_state['values']['saveguard_forms_all']) && $form_state['values']['saveguard_forms_all'] == 2) || (!isset($form_state['values']['saveguard_forms_all']) && $saveguard_forms_all == 2)) {
++    $form['saveguard_forms_container']['saveguard_except_forms'] = array(
++      '#type' => 'textarea',
++      '#title' => t("List of form_id's exceptions"),
++      '#description' => t("Specify a list of exceptions (form_ids) where you want SaveGuard not to apply."),
++      '#default_value' => $saveguard_except_forms_value,
++    );
++  }
+   return system_settings_form($form);
+ }
+ 
++/**
++ * AJAX Callback for the radios choice.
++ */
++function saveguard_forms_all_choice($form, $form_state) {
++  return $form['saveguard_forms_container'];
++}
+ 
+ /**
+  * Implements hook_form_alter().
+@@ -50,6 +103,45 @@ function saveguard_admin_settings() {
+  *    array with form structure
+  */
+ function saveguard_form_alter(&$form, &$form_state, $form_id) {
++  static $saveguard_form_ids_string;
++  static $saveguard_except_forms_ids_string;
++
++  $form_opt_type = variable_get('saveguard_forms_all', 0);
++  if (!isset($saveguard_form_ids_string)) {
++    $saveguard_form_ids_string = variable_get('saveguard_forms', '');
++  }
++  if (!isset($saveguard_except_forms_ids_string)) {
++    $saveguard_except_forms_ids_string = variable_get('saveguard_except_forms', '');
++  }
++
++  switch ($form_opt_type) {
++    case 0:
++      // We simply apply to all forms (default).
++      _saveguard_add_form_guard();
++      break;
++
++    case 1:
++      // We apply only to specified form_id's.
++      $saveguard_form_ids = list_extract_allowed_values($saveguard_form_ids_string, 'list_number', TRUE);
++      if (count($saveguard_form_ids) > 0 && in_array($form_id, $saveguard_form_ids)) {
++        _saveguard_add_form_guard();
++      }
++
++      break;
++    case 2:
++      // We apply to all forms except the specified form_ids.
++      $saveguard_except_forms_ids = list_extract_allowed_values($saveguard_except_forms_ids_string, 'list_number', TRUE);
++      if (!in_array($form_id, $saveguard_except_forms_ids)) {
++        _saveguard_add_form_guard();
++      }
++      break;
++  }
++}
++
++/**
++ * Private function that adds the saveguard itself.
++ */
++function _saveguard_add_form_guard() {
+   drupal_add_js(drupal_get_path('module', 'saveguard') . '/saveguard.js');
+   static $done;
+   if (!$done) {


### PR DESCRIPTION
After applying this patch it's possible to disable Saveguard functionality on certain forms.

Basically this patch does the following:
- Extends Form Settings to 3 options (Ajax-based): All forms, Form IDs list, Except Form_IDs
- Adds the SaveGuard only to those (depending on the rule)
