### PR TITLE
Add core patch for unset missing files.

### DIFF
--- a/drupal/unset-missing-files-920840/7.50-file-field-load-unset-missing-files-920840-16.patch
+++ b/drupal/unset-missing-files-920840/7.50-file-field-load-unset-missing-files-920840-16.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/file/file.field.inc b/modules/file/file.field.inc
+index 59b547a..c05ab5c 100644
+--- a/modules/file/file.field.inc
++++ b/modules/file/file.field.inc
+@@ -183,7 +183,7 @@ function file_field_load($entity_type, $entities, $field, $instances, $langcode,
+     foreach ($items[$id] as $delta => $item) {
+       // If the file does not exist, mark the entire item as empty.
+       if (empty($item['fid']) || !isset($files[$item['fid']])) {
+-        $items[$id][$delta] = NULL;
++        unset($items[$id][$delta]);
+       }
+       else {
+         $items[$id][$delta] = array_merge((array) $files[$item['fid']], $item);

--- a/drupal/unset-missing-files-920840/README.md
+++ b/drupal/unset-missing-files-920840/README.md
@@ -1,0 +1,6 @@
+# Patch summary
+
+Fix problem with broken images displayed and PHP notices 
+when file/image field values are missing.
+
+See https://www.drupal.org/node/920840 for details.


### PR DESCRIPTION
Fix problem with broken images displayed and PHP notices when file/image field values are missing.

See https://www.drupal.org/node/920840 for details.
